### PR TITLE
Fix function for generating random 503s

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,8 +2,9 @@ import json
 import requests
 from string import Template
 import time
+import random
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from util import generate_5xx, artificial_latency
+from util import artificial_503, artificial_latency
 
 
 HOST_NAME = '0.0.0.0' # This will map to avialable port in docker
@@ -14,17 +15,16 @@ with open('./templates/treeCounter.html', 'r') as f:
 html_template = Template(html_string)
 
 def fetch_tree_count():
-	r = requests.get(trees_api_url)
-	if r.status_code == 200:
-		return r.json()['count']
-	return 0
+       r = requests.get(trees_api_url) if random.random() > 0.15 else artificial_503()
+       if r.status_code == 200:
+               return r.json()['count']
+       return 0
 
 
 
 class HTTPRequestHandler(BaseHTTPRequestHandler):
 
     @artificial_latency
-    @generate_5xx
     def get_treecounter(self):
         self.do_HEAD()
         tree_count = fetch_tree_count()

--- a/app/util.py
+++ b/app/util.py
@@ -1,16 +1,14 @@
 import random
+from requests import Response
 from time import sleep
 
+def artificial_503():
+    r = Response()
+    r.status_code = 503
+    r.reason = "Uh oh - artificial 503"
+    r.json = {}
+    return r
 
-def generate_5xx(func):
-    def randomised_503(request_handler):
-        random_number = random.random()
-        if not random_number < 0.15:
-            return func(request_handler)
-        request_handler.send_response(503, 'Fake 503 (service available) response')
-        request_handler.send_header('Content-type', 'text/html')
-        request_handler.end_headers()
-    return randomised_503
 
 def artificial_latency(func):
     def randomised_latency(request_handler):


### PR DESCRIPTION
Update function for generating random 503s so that it influences the response of the `/tree` endpoint instead of `/treecounter`